### PR TITLE
test: mock clerk themes and set db url

### DIFF
--- a/__tests__/app/root-layout.test.tsx
+++ b/__tests__/app/root-layout.test.tsx
@@ -1,13 +1,17 @@
 import { render } from '@testing-library/react'
-import RootLayout, { metadata } from '../../app/layout'
 
 jest.mock('@clerk/nextjs', () => ({
   ClerkProvider: ({ children }: any) => <div data-testid="clerk">{children}</div>
 }))
 
+// Mock Clerk themes to avoid missing module errors during tests
+jest.mock('@clerk/themes', () => ({ dark: {} }), { virtual: true })
+
 jest.mock('next/font/google', () => ({
   Inter: () => ({ className: 'font', variable: '--font' })
 }))
+
+import RootLayout, { metadata } from '../../app/layout'
 
 describe('RootLayout', () => {
   const originalEnv = process.env

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,5 +1,8 @@
 import '@testing-library/jest-dom'
 
+// Ensure a default database URL so modules depending on it can load in tests
+process.env.DATABASE_URL = process.env.DATABASE_URL || 'postgres://localhost/test-db'
+
 // Suppress console.error and console.warn during tests to keep output clean
 const originalError = console.error
 const originalWarn = console.warn


### PR DESCRIPTION
## Summary
- mock `@clerk/themes` in root layout test to avoid missing module errors
- provide default `DATABASE_URL` in Jest setup so components using the database can load

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a86406058c832fbfa4437b220bf776