### PR TITLE
fix: type message markdown and reset github cache

### DIFF
--- a/__tests__/app/api/auth/github-api.test.ts
+++ b/__tests__/app/api/auth/github-api.test.ts
@@ -10,11 +10,15 @@ jest.mock('@octokit/rest', () => {
   }
 })
 
-import { fetchGitHubOrganizations } from '../../../../app/api/auth/callback/github/api'
+import {
+  fetchGitHubOrganizations,
+  clearGitHubApiCache
+} from '../../../../app/api/auth/callback/github/api'
 
 describe('fetchGitHubOrganizations', () => {
   beforeEach(() => {
     listForAuthUser.mockReset()
+    clearGitHubApiCache()
   })
 
   it('returns organization list', async () => {

--- a/app/api/auth/callback/github/api.ts
+++ b/app/api/auth/callback/github/api.ts
@@ -26,6 +26,10 @@ function setCachedResult<T>(cacheKey: string, data: T): void {
   apiCache.set(cacheKey, { data, timestamp: Date.now() })
 }
 
+export function clearGitHubApiCache() {
+  apiCache.clear()
+}
+
 async function fetchWithRetry<T>(
   fn: () => Promise<T>,
   maxRetries = 3

--- a/components/instructions/message-markdown.tsx
+++ b/components/instructions/message-markdown.tsx
@@ -1,5 +1,10 @@
 import { cn } from "@/lib/utils"
-import React, { FC, HTMLAttributes, useMemo } from "react"
+import React, {
+  FC,
+  HTMLAttributes,
+  ReactNode,
+  useMemo
+} from "react"
 import remarkGfm from "remark-gfm"
 import remarkMath from "remark-math"
 import { MessageCodeBlock } from "./message-codeblock"
@@ -15,20 +20,20 @@ export const MessageMarkdown: FC<MessageMarkdownProps> = ({
   const remarkPlugins = useMemo(() => [remarkGfm, remarkMath], [])
   
   const components = useMemo(() => ({
-    p({ children }) {
+    p({ children }: { children?: ReactNode }) {
       return <p className="mb-2 last:mb-0">{children}</p>
     },
-    img({ ...props }) {
+    img(props: React.ImgHTMLAttributes<HTMLImageElement>) {
       return <img className="max-w-[67%]" {...props} />
     },
-    a({ href, children, ...props }) {
+    a({ href, children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) {
       return (
         <a href={href} target="_blank" rel="noopener noreferrer" {...props}>
           {children}
         </a>
       )
     },
-    code({ className, children, ...props }) {
+    code({ className, children, ...props }: { className?: string; children?: ReactNode }) {
       const childArray = React.Children.toArray(children)
       const firstChild = childArray[0] as React.ReactElement
       const firstChildAsString = React.isValidElement(firstChild)


### PR DESCRIPTION
## Summary
- add explicit React types to `MessageMarkdown` rendering helpers
- export a helper to clear the GitHub API cache and use it in tests

## Testing
- `npm test`
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68bf2113b490832fabe980823215bd54